### PR TITLE
How to persiste a volume of a database

### DIFF
--- a/persistant-volume/create-pvclaim.yaml
+++ b/persistant-volume/create-pvclaim.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgres-pvc
+  labels:
+    app: postgres
+spec:
+  storageClassName: manual
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 1Gi
+      

--- a/persistant-volume/persist-volume.yaml
+++ b/persistant-volume/persist-volume.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: postgresdb-pv
+  labels:
+    type: local
+    app: postgres
+spec:
+  storageClassName: manual
+  capacity:
+    storage: 1Gi
+  accessModes:
+    - ReadWriteMany
+  hostPath:
+    path: /data/postgresql
+    

--- a/persistant-volume/postgresql-pv.yaml
+++ b/persistant-volume/postgresql-pv.yaml
@@ -1,0 +1,44 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: postgres-config
+  labels:
+    app: postgres
+data:
+  POSTGRES_DB: postgresdb
+  POSTGRES_USER: admin12
+  POSTGRES_PASSWORD: Toronto123
+
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgres-db
+spec:
+  serviceName: postgres-db
+  selector:
+    matchLabels:
+      app: postgres-db
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: postgres-db
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:13.18
+          imagePullPolicy: "IfNotPresent"
+          ports:
+          - containerPort: 5432
+          envFrom:
+          - configMapRef:
+              name: postgres-config
+          volumeMounts:
+          - name: dbdata
+            mountPath: /var/lib/postgresql/data
+      volumes:
+      - name: dbdata
+        persistentVolumeClaim:
+          claimName: postgres-pvc
+          


### PR DESCRIPTION
This Kubernetes configuration sets up a stateful PostgreSQL database using a PersistentVolume (PV) and PersistentVolumeClaim (PVC) for data persistence, a ConfigMap for managing database credentials, and a StatefulSet to ensure stable deployment. The PV provides 1Gi of storage at /data/postgresql, while the PVC requests this storage for the PostgreSQL pod. The ConfigMap injects database settings as environment variables, and the StatefulSet ensures PostgreSQL runs with persistent data, automatic rescheduling, and stability, exposing port 5432 for access.